### PR TITLE
Hide (<>) for Prelude >= 4.11.0

### DIFF
--- a/djinn-lib/src/Djinn/HTypes.hs
+++ b/djinn-lib/src/Djinn/HTypes.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 --
 -- Copyright (c) 2005 Lennart Augustsson
 -- See LICENSE for licensing details.
@@ -30,6 +31,9 @@ module Djinn.HTypes(
 import Control.Monad (zipWithM)
 import Data.Char (isAlpha, isAlphaNum, isUpper)
 import Data.List (union, (\\))
+#ifdef MIN_VERSION_base(4,11,0)
+import Prelude hiding ((<>))
+#endif
 import Text.ParserCombinators.ReadP
 import Text.PrettyPrint.HughesPJ (Doc, comma, fsep, nest, parens,
                                   punctuate, renderStyle, sep,


### PR DESCRIPTION
Prelude >= 4.11.0 exports `(<>)` from `Data.Semigroups`, which conflicts with `(<>)` from `Text.PrettyPrint.HughesPJ`. This PR hides the `(<>)` from `Prelude`.