### PR TITLE
Require cabal-version 1.8

### DIFF
--- a/djinn-lib/djinn-lib.cabal
+++ b/djinn-lib/djinn-lib.cabal
@@ -1,6 +1,6 @@
 name:           djinn-lib
 version:        0.0.1.2
-cabal-version:  >= 1.2
+cabal-version:  >= 1.8
 license:        BSD3
 license-file:	LICENSE
 author:	        Lennart Augustsson


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: djinn-lib.cabal:18:32: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```