### PR TITLE
Fix base version check

### DIFF
--- a/djinn-lib/src/Djinn/HTypes.hs
+++ b/djinn-lib/src/Djinn/HTypes.hs
@@ -31,7 +31,7 @@ module Djinn.HTypes(
 import Control.Monad (zipWithM)
 import Data.Char (isAlpha, isAlphaNum, isUpper)
 import Data.List (union, (\\))
-#ifdef MIN_VERSION_base(4,11,0)
+#if MIN_VERSION_base(4,11,0)
 import Prelude hiding ((<>))
 #endif
 import Text.ParserCombinators.ReadP


### PR DESCRIPTION
Fixes the following error:
```
src/Djinn/HTypes.hs:34:0: error:
     warning: extra tokens at end of #ifdef directive
       34 | #ifdef MIN_VERSION_base(4,11,0)
          |
   |
34 | #ifdef MIN_VERSION_base(4,11,0)
   | ^
```